### PR TITLE
Fix/persist notes across refresh

### DIFF
--- a/src/app/ui/CookbookNotes.tsx
+++ b/src/app/ui/CookbookNotes.tsx
@@ -15,7 +15,7 @@ export default function CookbookNotes({ notes, onSave }: CookbookNotesProps) {
 
   useEffect(() => {
     if (notesElRef.current) notesElRef.current.innerText = notes
-  }, [])
+  })
 
   return (
     <>

--- a/src/app/ui/CookbookNotes.tsx
+++ b/src/app/ui/CookbookNotes.tsx
@@ -31,35 +31,31 @@ export default function CookbookNotes({ notes, onSave }: CookbookNotesProps) {
           ref={notesElRef}></textarea>
       </AccordionDetails>
       <AccordionActions className="pt-0">
-        {!editing ? (
+        {editing ? (
           <ThemedButton
-            color="mvc-yellow"
+            color="mvc-gray"
+            variant="outlined"
             onClick={() => {
-              setEditing(true)
-              notesElRef?.current?.focus()
+              setEditing(false)
             }}>
-            Edit
+            Cancel
           </ThemedButton>
-        ) : (
-          <>
-            <ThemedButton
-              color="mvc-gray"
-              variant="outlined"
-              onClick={() => {
-                setEditing(false)
-              }}>
-              Cancel
-            </ThemedButton>
-            <ThemedButton
-              onClick={async () => {
+        ) : null}
+        {
+          <ThemedButton
+            onClick={async () => {
+              if (editing) {
                 setEditing(false)
                 onSave(notesElRef.current?.value || '')
-              }}
-              color="mvc-green">
-              Save
-            </ThemedButton>
-          </>
-        )}
+              } else {
+                setEditing(true)
+                notesElRef?.current?.focus()
+              }
+            }}
+            color={editing ? 'mvc-green' : 'mvc-yellow'}>
+            {editing ? 'Save' : 'Edit'}
+          </ThemedButton>
+        }
       </AccordionActions>
     </>
   )


### PR DESCRIPTION
- Remove empty dependency array to set notes on refreshes
- Fix weird color shift in `CookbookNotes` buttons